### PR TITLE
Auto fields.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ django-pb-model
 
 
 Django-pb-model provides model mixin mapping/converting protobuf message.
+Automatic model generation from protobuf message definitions is supported.
 Currently support basic value fields and naive relation conversion, including:
 
 * Integer, String, Float, Boolean
@@ -114,6 +115,45 @@ By above settings, you can covert between django model and protobuf easily. For 
    >>> account2.from_pb(account.to_pb())
    <Account: Username: username@mail, nickname: moonmoon>
 
+
+Automatic field generation
+--------------------------
+
+To automatically generate django model fields based on protobuf field types.
+
+If you don't want to manually specify fields in your django model, you can list names of desired fields under ``pb_2_dj_fields`` attribute to have those generated and added to your model automatically.
+
+.. code:: python
+
+    class Account(ProtoBufMixin, models.Model):
+        pb_model = account_pb2.Account
+        pb_2_dj_fields = ['email', 'nickname']
+
+
+Alternatively if you want all protobuf fields to be mapped you can do ``pb_2_dj_fields = '__all__'``.
+
+Fields listed in ``pb_2_dj_fields`` can be overwritten using manuall definition.
+
+.. code:: python
+
+    class Account(ProtoBufMixin, models.Model):
+        pb_model = account_pb2.Account
+        pb_2_dj_fields = '__all__'
+        
+        email = models.EmailField(max_length=64)
+
+
+Type of generated field depends on corresponding protobuf field type. If you want to change default field type mappings you can overwrite those using ``pb_auto_field_type_mapping`` attribute.
+
+Following protobuf field types are supported:
+
+* uint32, int32, uint64, int64, float, double, bool, Enum
+* string, bytes
+* google.protobuf.Timestamp
+* Messages
+* oneof fields
+* repeated scalar and Message fields
+* map fields with scalar as key and scalar or Message as value
 
 Field details
 -------------

--- a/pb_model/fields.py
+++ b/pb_model/fields.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 import logging
 import json
 import uuid
@@ -31,6 +32,8 @@ def _defaultfield_to_pb(pb_obj, pb_field, dj_field_value):
     """ handling any fields conversion to protobuf
     """
     LOGGER.debug("Django Value field, assign proto msg field: {} = {}".format(pb_field.name, dj_field_value))
+    if sys.version_info < (3,) and type(dj_field_value) is buffer:
+        dj_field_value = bytes(dj_field_value)
     setattr(pb_obj, pb_field.name, dj_field_value)
 
 
@@ -101,7 +104,7 @@ class ProtoBufFieldMixin(object):
 
 
 class JSONField(models.TextField):
-    def from_db_value(self, value, expression, connection):
+    def from_db_value(self, value, expression, connection, context=None):
         return self._deserialize(value)
 
     def to_python(self, value):
@@ -143,7 +146,7 @@ class MapField(JSONField, ProtoBufFieldMixin):
 class RepeatedMessageField(models.ManyToManyField, ProtoBufFieldMixin):
     class Descriptor(models.fields.related_descriptors.ManyToManyDescriptor):
         def __init__(self, field_name, index_field_name, rel, reverse=False):
-            super().__init__(rel, reverse)
+            super(RepeatedMessageField.Descriptor, self).__init__(rel, reverse)
             self._field_name = field_name
             self._index_field_name = index_field_name
 
@@ -159,25 +162,25 @@ class RepeatedMessageField(models.ManyToManyField, ProtoBufFieldMixin):
             instance.__dict__[self._field_name] = value
 
     def __init__(self, *args, **kwargs):
-        super().__init__(default=[], *args, **kwargs)
+        super(RepeatedMessageField, self).__init__(default=[], *args, **kwargs)
 
     def deconstruct(self):
-        name, path, args, kwargs = super().deconstruct()
+        name, path, args, kwargs = super(RepeatedMessageField, self).deconstruct()
         kwargs.pop('default')
         return name, path, args, kwargs
 
     def contribute_to_class(self, cls, name):
-        index_field_name = f'{name}_index'
+        index_field_name = '%s_index' % name
         index_field = JSONField(default=[], editable=False, blank=True)
         index_field.creation_counter = self.creation_counter
         cls.add_to_class(index_field_name, index_field)
-        super().contribute_to_class(cls, name)
+        super(RepeatedMessageField, self).contribute_to_class(cls, name)
         setattr(cls, self.attname, RepeatedMessageField.Descriptor(name, index_field_name, self.remote_field, reverse=False))
 
     def save(self, instance):
         for message in getattr(instance, self.attname):
             type(instance).__dict__[self.attname].related_manager_cls(instance).add(message)
-        setattr(instance, f'{self.attname}_index', [q.id for q in instance.__dict__[self.attname]])
+        setattr(instance, '%s_index' % self.attname, [q.id for q in instance.__dict__[self.attname]])
 
     def load(self, instance):
         getattr(instance, self.attname)
@@ -195,7 +198,7 @@ class RepeatedMessageField(models.ManyToManyField, ProtoBufFieldMixin):
 class MessageMapField(models.ManyToManyField, ProtoBufFieldMixin):
     class Descriptor(models.fields.related_descriptors.ManyToManyDescriptor):
         def __init__(self, field_name, index_field_name, rel, reverse=False):
-            super().__init__(rel, reverse)
+            super(MessageMapField.Descriptor, self).__init__(rel, reverse)
             self._field_name = field_name
             self._index_field_name = index_field_name
 
@@ -211,25 +214,25 @@ class MessageMapField(models.ManyToManyField, ProtoBufFieldMixin):
             instance.__dict__[self._field_name] = value
 
     def __init__(self, *args, **kwargs):
-        super().__init__(default={}, *args, **kwargs)
+        super(MessageMapField, self).__init__(default={}, *args, **kwargs)
 
     def deconstruct(self):
-        name, path, args, kwargs = super().deconstruct()
+        name, path, args, kwargs = super(MessageMapField, self).deconstruct()
         kwargs.pop('default')
         return name, path, args, kwargs
 
     def contribute_to_class(self, cls, name):
-        index_field_name = f'{name}_index'
+        index_field_name = '%s_index' % name
         index_field = JSONField(default={}, editable=False, blank=True)
         index_field.creation_counter = self.creation_counter
         cls.add_to_class(index_field_name, index_field)
-        super().contribute_to_class(cls, name)
+        super(MessageMapField, self).contribute_to_class(cls, name)
         setattr(cls, self.attname, MessageMapField.Descriptor(name, index_field_name, self.remote_field, reverse=False))
 
     def save(self, instance):
         for message in getattr(instance, self.attname).values():
             type(instance).__dict__[self.attname].related_manager_cls(instance).add(message)
-        setattr(instance, f'{self.attname}_index', {key: message.id for key, message in instance.__dict__[self.attname].items()})
+        setattr(instance, '%s_index' % self.attname, {key: message.id for key, message in instance.__dict__[self.attname].items()})
 
     def load(self, instance):
         getattr(instance, self.attname)

--- a/pb_model/fields.py
+++ b/pb_model/fields.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import json
+import uuid
+
+from django.db import models
+from django.conf import settings
+from django.utils import timezone
+
+from google.protobuf.descriptor import FieldDescriptor
+
+
+logging.basicConfig()
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.WARNING)
+if settings.DEBUG:
+    LOGGER.setLevel(logging.DEBUG)
+
+
+PB_FIELD_TYPE_TIMESTAMP = FieldDescriptor.MAX_TYPE + 1
+PB_FIELD_TYPE_REPEATED = FieldDescriptor.MAX_TYPE + 2
+PB_FIELD_TYPE_MAP = FieldDescriptor.MAX_TYPE + 3
+PB_FIELD_TYPE_MESSAGE = FieldDescriptor.MAX_TYPE + 4
+PB_FIELD_TYPE_REPEATED_MESSAGE = FieldDescriptor.MAX_TYPE + 5
+PB_FIELD_TYPE_MESSAGE_MAP = FieldDescriptor.MAX_TYPE + 6
+
+
+class ProtoBufFieldMixin(object):
+    @staticmethod
+    def to_pb(pb_obj, pb_field, dj_field_value):
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_pb(instance, dj_field_name, pb_field, pb_value):
+        raise NotImplementedError()
+
+
+class JSONField(models.TextField):
+    def from_db_value(self, value, expression, connection):
+        return self._deserialize(value)
+
+    def to_python(self, value):
+        if isinstance(value, str):
+            return self._deserialize(value)
+
+        return value
+
+    def get_prep_value(self, value):
+        return json.dumps(value)
+
+    def _deserialize(self, value):
+        if value is None:
+            return None
+
+        return json.loads(value)
+
+
+class ArrayField(JSONField, ProtoBufFieldMixin):
+    @staticmethod
+    def to_pb(pb_obj, pb_field, dj_field_value):
+        getattr(pb_obj, pb_field.name).extend(dj_field_value)
+
+    @staticmethod
+    def from_pb(instance, dj_field_name, pb_field, pb_value):
+        setattr(instance, dj_field_name, list(pb_value))
+
+
+class MapField(JSONField, ProtoBufFieldMixin):
+    @staticmethod
+    def to_pb(pb_obj, pb_field, dj_field_value):
+        getattr(pb_obj, pb_field.name).update(dj_field_value)
+
+    @staticmethod
+    def from_pb(instance, dj_field_name, pb_field, pb_value):
+        setattr(instance, dj_field_name, dict(pb_value))
+
+
+class RepeatedMessageField(models.ManyToManyField, ProtoBufFieldMixin):
+    class Descriptor(models.fields.related_descriptors.ManyToManyDescriptor):
+        def __init__(self, field_name, index_field_name, rel, reverse=False):
+            super().__init__(rel, reverse)
+            self._field_name = field_name
+            self._index_field_name = index_field_name
+
+        def __get__(self, instance, cls=None):
+            if instance is None:
+                raise AttributeError('Can only be accessed via an instance.')
+
+            if self._field_name not in instance.__dict__:
+                instance.__dict__[self._field_name] = [self.related_manager_cls(instance).get(id=id_) for id_ in getattr(instance, self._index_field_name)]
+            return instance.__dict__[self._field_name]
+
+        def __set__(self, instance, value):
+            instance.__dict__[self._field_name] = value
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(default=[], *args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs.pop('default')
+        return name, path, args, kwargs
+
+    def contribute_to_class(self, cls, name):
+        index_field_name = f'{name}_index'
+        index_field = JSONField(default=[], editable=False, blank=True)
+        index_field.creation_counter = self.creation_counter
+        cls.add_to_class(index_field_name, index_field)
+        super().contribute_to_class(cls, name)
+        setattr(cls, self.attname, RepeatedMessageField.Descriptor(name, index_field_name, self.remote_field, reverse=False))
+
+    def save(self, instance):
+        for message in getattr(instance, self.attname):
+            type(instance).__dict__[self.attname].related_manager_cls(instance).add(message)
+        setattr(instance, f'{self.attname}_index', [q.id for q in instance.__dict__[self.attname]])
+
+    def load(self, instance):
+        getattr(instance, self.attname)
+
+    @staticmethod
+    def to_pb(pb_obj, pb_field, dj_field_value):
+        getattr(pb_obj, pb_field.name).extend([m.to_pb() for m in dj_field_value])
+
+    @staticmethod
+    def from_pb(instance, dj_field_name, pb_field, pb_value):
+        related_model = instance._meta.get_field(dj_field_name).related_model
+        setattr(instance, dj_field_name, [related_model().from_pb(pb_message) for pb_message in pb_value])
+
+
+class MessageMapField(models.ManyToManyField, ProtoBufFieldMixin):
+    class Descriptor(models.fields.related_descriptors.ManyToManyDescriptor):
+        def __init__(self, field_name, index_field_name, rel, reverse=False):
+            super().__init__(rel, reverse)
+            self._field_name = field_name
+            self._index_field_name = index_field_name
+
+        def __get__(self, instance, cls=None):
+            if instance is None:
+                raise AttributeError('Can only be accessed via an instance.')
+
+            if self._field_name not in instance.__dict__:
+                instance.__dict__[self._field_name] = {key: self.related_manager_cls(instance).get(id=id_) for key, id_ in getattr(instance, self._index_field_name).items()}
+            return instance.__dict__[self._field_name]
+
+        def __set__(self, instance, value):
+            instance.__dict__[self._field_name] = value
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(default={}, *args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs.pop('default')
+        return name, path, args, kwargs
+
+    def contribute_to_class(self, cls, name):
+        index_field_name = f'{name}_index'
+        index_field = JSONField(default={}, editable=False, blank=True)
+        index_field.creation_counter = self.creation_counter
+        cls.add_to_class(index_field_name, index_field)
+        super().contribute_to_class(cls, name)
+        setattr(cls, self.attname, MessageMapField.Descriptor(name, index_field_name, self.remote_field, reverse=False))
+
+    def save(self, instance):
+        for message in getattr(instance, self.attname).values():
+            type(instance).__dict__[self.attname].related_manager_cls(instance).add(message)
+        setattr(instance, f'{self.attname}_index', {key: message.id for key, message in instance.__dict__[self.attname].items()})
+
+    def load(self, instance):
+        getattr(instance, self.attname)
+
+    @staticmethod
+    def to_pb(pb_obj, pb_field, dj_field_value):
+        for key in dj_field_value:
+            getattr(pb_obj, pb_field.name)[key].CopyFrom(dj_field_value[key].to_pb())
+
+    @staticmethod
+    def from_pb(instance, dj_field_name, pb_field, pb_value):
+        related_model = instance._meta.get_field(dj_field_name).related_model
+        setattr(instance, dj_field_name, {key: related_model().from_pb(pb_message) for key, pb_message in pb_value.items()})

--- a/pb_model/fields.py
+++ b/pb_model/fields.py
@@ -27,6 +27,69 @@ PB_FIELD_TYPE_REPEATED_MESSAGE = FieldDescriptor.MAX_TYPE + 5
 PB_FIELD_TYPE_MESSAGE_MAP = FieldDescriptor.MAX_TYPE + 6
 
 
+def _defaultfield_to_pb(pb_obj, pb_field, dj_field_value):
+    """ handling any fields conversion to protobuf
+    """
+    LOGGER.debug("Django Value field, assign proto msg field: {} = {}".format(pb_field.name, dj_field_value))
+    setattr(pb_obj, pb_field.name, dj_field_value)
+
+
+def _defaultfield_from_pb(instance, dj_field_name, pb_field, pb_value):
+    """ handling any fields setting from protobuf
+    """
+    LOGGER.debug("Django Value Field, set dj field: {} = {}".format(dj_field_name, pb_value))
+    setattr(instance, dj_field_name, pb_value)
+
+
+def _datetimefield_to_pb(pb_obj, pb_field, dj_field_value):
+    """handling Django DateTimeField field
+
+    :param pb_obj: protobuf message obj which is return value of to_pb()
+    :param pb_field: protobuf message field which is current processing field
+    :param dj_field_value: Currently proecessing django field value
+    :returns: None
+    """
+    if getattr(getattr(pb_obj, pb_field.name), 'FromDatetime', False):
+        if settings.USE_TZ:
+            dj_field_value = timezone.make_naive(dj_field_value, timezone=timezone.utc)
+        getattr(pb_obj, pb_field.name).FromDatetime(dj_field_value)
+
+
+def _datetimefield_from_pb(instance, dj_field_name, pb_field, pb_value):
+    """handling datetime field (Timestamp) object to dj field
+
+    :param dj_field_name: Currently target django field's name
+    :param pb_value: Currently processing protobuf message value
+    :returns: None
+    """
+    dt = pb_value.ToDatetime()
+    if settings.USE_TZ:
+        dt = timezone.localtime(timezone.make_aware(dt, timezone.utc))
+    # FIXME: not datetime field
+    setattr(instance, dj_field_name, dt)
+
+
+def _uuid_to_pb(pb_obj, pb_field, dj_field_value):
+    """handling Django UUIDField field
+
+    :param pb_obj: protobuf message obj which is return value of to_pb()
+    :param pb_field: protobuf message field which is current processing field
+    :param dj_field_value: Currently proecessing django field value
+    :returns: None
+    """
+    setattr(pb_obj, pb_field.name, str(dj_field_value))
+
+
+def _uuid_from_pb(instance, dj_field_name, pb_field, pb_value):
+    """handling string object to dj UUIDField
+
+    :param dj_field_name: Currently target django field's name
+    :param pb_value: Currently processing protobuf message value
+    :returns: None
+    """
+    setattr(instance, dj_field_name, uuid.UUID(pb_value))
+
+
 class ProtoBufFieldMixin(object):
     @staticmethod
     def to_pb(pb_obj, pb_field, dj_field_value):

--- a/pb_model/models.py
+++ b/pb_model/models.py
@@ -65,7 +65,132 @@ class DjangoPBModelError(Exception):
     pass
 
 
-class ProtoBufMixin(object):
+class Meta(type(models.Model)):
+    def __init__(self, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        self._pb_2_dj_field_serializers = self._pb_2_dj_field_serializers.copy()
+        self._pb_2_dj_field_serializers.update(self.pb_2_dj_field_serializers)
+
+        self._pb_auto_field_type_mapping = self._pb_auto_field_type_mapping.copy()
+        self._pb_auto_field_type_mapping.update(self.pb_auto_field_type_mapping)
+
+        if self.pb_model is not None:
+            if self.pb_2_dj_fields == '__all__':
+                self.pb_2_dj_fields = self.pb_model.DESCRIPTOR.fields_by_name.keys()
+
+            for pb_field_name in self.pb_2_dj_fields:
+                pb_field_descriptor = self.pb_model.DESCRIPTOR.fields_by_name[pb_field_name]
+                dj_field_name = self.pb_2_dj_field_map.get(pb_field_name, pb_field_name)
+                if dj_field_name not in attrs:
+                    field = self._create_field(pb_field_descriptor)
+                    if field is not None:
+                        field.contribute_to_class(self, dj_field_name)
+
+    def _create_field(self, message_field):
+        message_field_type = message_field.type
+
+        if Meta._is_message_map_field(message_field):
+            mapped_message = message_field.message_type.fields_by_name['value'].message_type
+            return self._create_message_map_field(message_field.containing_type.name, mapped_message.name, message_field.name)
+        elif Meta._is_map_field(message_field):
+            return self._create_map_field()
+        elif Meta._is_repeated_message_field(message_field):
+            return self._create_repeated_message_field(message_field.containing_type.name, message_field.message_type.name, message_field.name)
+        elif Meta._is_repeated_field(message_field):
+            return self._create_repeated_field()
+        elif Meta._is_message_field(message_field):
+            if message_field.message_type.name == 'Timestamp':
+                return self._create_timestamp_field()
+            else:
+                return self._create_message_field(message_field.containing_type.name, message_field.message_type.name, message_field.name)
+        else:
+            return self._create_generic_field(message_field_type)
+
+    @staticmethod
+    def _is_message_field(field_descriptor):
+        return field_descriptor.message_type is not None
+
+    @staticmethod
+    def _is_repeated_field(field_descriptor):
+        return field_descriptor.label == field_descriptor.LABEL_REPEATED
+
+    @staticmethod
+    def _is_repeated_message_field(field_descriptor):
+        """
+        Checks if a given field is a protobuf repeated field.
+        :param field_descriptor: protobuf field descriptor
+        :return: bool
+        """
+        return Meta._is_repeated_field(field_descriptor) and Meta._is_message_field(field_descriptor)
+
+    @staticmethod
+    def _is_map_field(field_descriptor):
+        """
+        Checks if a given field is a protobuf map to native field (map<int/float/str/etc., int/float/str/etc.>).
+        :param field_descriptor: protobuf field descriptor
+        :return: bool
+        """
+        return field_descriptor.message_type is not None and set(field_descriptor.message_type.fields_by_name.keys()) == {'key', 'value'}
+
+    @staticmethod
+    def _is_message_map_field(field_descriptor):
+        """
+        Checks if a given field is a protobuf map to message field (map<int/float/str/etc., Message>).
+        :param field_descriptor: protobuf field descriptor
+        :return: bool
+        """
+        return Meta._is_map_field(field_descriptor) and Meta._is_message_field(field_descriptor.message_type.fields_by_name['value'])
+
+    def _create_generic_field(self, type_):
+        """
+        Creates a django field of the type that is defined in `_pb_auto_field_type_mapping_`.
+        :param type_: Protobuf field type.
+        :return: Django field.
+        """
+        field_type = self._pb_auto_field_type_mapping[type_]
+        return field_type(null=True)
+
+    def _create_timestamp_field(self):
+        field_type = self._pb_auto_field_type_mapping[fields.PB_FIELD_TYPE_TIMESTAMP]
+        return field_type()
+
+    def _create_map_field(self):
+        field_type = self._pb_auto_field_type_mapping[fields.PB_FIELD_TYPE_MAP]
+        return field_type()
+
+    def _create_repeated_field(self):
+        field_type = self._pb_auto_field_type_mapping[fields.PB_FIELD_TYPE_REPEATED]
+        return field_type()
+
+    def _create_message_field(self, own_type, related_type, field_name):
+        field_type = self._pb_auto_field_type_mapping[fields.PB_FIELD_TYPE_MESSAGE]
+        return field_type(to=related_type, related_name='%s_%s' % (own_type, field_name), on_delete=models.deletion.CASCADE, null=True)
+
+    def _create_repeated_message_field(self, own_type, related_type, field_name):
+        """
+        Creates a django relation that mimics a repeated message field.
+        :param own_type: Name of the message that contains this field.
+        :param related_type: Name of the message with which the relation is established.
+        :param field_name: Name of the created field.
+        :return: RepeatedMessageField
+        """
+        field_type = self._pb_auto_field_type_mapping[fields.PB_FIELD_TYPE_REPEATED_MESSAGE]
+        return field_type(to=related_type, related_name=f'{own_type}_{field_name}')
+
+    def _create_message_map_field(self, own_type, related_type, field_name):
+        """
+        Creates a django relation that mimics a scalar to message map field.
+        :param own_type: Name of the message that contains this field.
+        :param related_type: Name of the message with which the relation is established.
+        :param field_name: Name of the created field.
+        :return: MapToMessageField
+        """
+        field_type = self._pb_auto_field_type_mapping[fields.PB_FIELD_TYPE_MESSAGE_MAP]
+        return field_type(to=related_type, related_name=f'{own_type}_{field_name}')
+
+
+class ProtoBufMixin(object, metaclass=Meta):
+    __metaclass__ = Meta
     """This is mixin for model.Model.
     By setting attribute ``pb_model``, you can specify target ProtoBuf Message
     to handle django model.
@@ -75,12 +200,37 @@ class ProtoBufMixin(object):
     """
 
     pb_model = None
+    pb_2_dj_fields = []  # list of pb field names that are mapped, special case pb_2_dj_fields = '__all__'
     pb_2_dj_field_map = {}  # pb field in keys, dj field in value
     pb_2_dj_field_serializers = {
     }  # dj field in key, serializer function pairs in value
     _default_pb_2_dj_field_serializers = {
         'DateTimeField': (_datetimefield_serializer,
                           _datetimefield_deserializer),
+    pb_auto_field_type_mapping = {}  # pb field type in key, dj field type in value
+    _pb_auto_field_type_mapping = {
+        FieldDescriptor.TYPE_DOUBLE: models.FloatField,
+        FieldDescriptor.TYPE_FLOAT: models.FloatField,
+        FieldDescriptor.TYPE_INT64: models.BigIntegerField,
+        FieldDescriptor.TYPE_UINT64: models.BigIntegerField,
+        FieldDescriptor.TYPE_INT32: models.IntegerField,
+        FieldDescriptor.TYPE_FIXED64: models.DecimalField,
+        FieldDescriptor.TYPE_FIXED32: models.DecimalField,
+        FieldDescriptor.TYPE_BOOL: models.NullBooleanField,
+        FieldDescriptor.TYPE_STRING: models.TextField,
+        FieldDescriptor.TYPE_BYTES: models.BinaryField,
+        FieldDescriptor.TYPE_UINT32: models.PositiveIntegerField,
+        FieldDescriptor.TYPE_ENUM: models.IntegerField,
+        FieldDescriptor.TYPE_SFIXED32: models.DecimalField,
+        FieldDescriptor.TYPE_SFIXED64: models.DecimalField,
+        FieldDescriptor.TYPE_SINT32: models.IntegerField,
+        FieldDescriptor.TYPE_SINT64: models.BigIntegerField,
+        fields.PB_FIELD_TYPE_TIMESTAMP: models.DateTimeField,
+        fields.PB_FIELD_TYPE_REPEATED: fields.ArrayField,
+        fields.PB_FIELD_TYPE_MAP: fields.MapField,
+        fields.PB_FIELD_TYPE_MESSAGE: models.ForeignKey,
+        fields.PB_FIELD_TYPE_REPEATED_MESSAGE: fields.RepeatedMessageField,
+        fields.PB_FIELD_TYPE_MESSAGE_MAP: fields.MessageMapField,
     }
     """
     {ProtoBuf-field-name: Django-field-name} key-value pair mapping to handle

--- a/pb_model/models.py
+++ b/pb_model/models.py
@@ -18,69 +18,6 @@ if settings.DEBUG:
     LOGGER.setLevel(logging.DEBUG)
 
 
-def _defaultfield_to_pb(pb_obj, pb_field, dj_field_value):
-    """ handling any fields conversion to protobuf
-    """
-    LOGGER.debug("Django Value field, assign proto msg field: {} = {}".format(pb_field.name, dj_field_value))
-    setattr(pb_obj, pb_field.name, dj_field_value)
-
-
-def _defaultfield_from_pb(instance, dj_field_name, pb_field, pb_value):
-    """ handling any fields setting from protobuf
-    """
-    LOGGER.debug("Django Value Field, set dj field: {} = {}".format(dj_field_name, pb_value))
-    setattr(instance, dj_field_name, pb_value)
-
-
-def _datetimefield_to_pb(pb_obj, pb_field, dj_field_value):
-    """handling Django DateTimeField field
-
-    :param pb_obj: protobuf message obj which is return value of to_pb()
-    :param pb_field: protobuf message field which is current processing field
-    :param dj_field_value: Currently proecessing django field value
-    :returns: None
-    """
-    if getattr(getattr(pb_obj, pb_field.name), 'FromDatetime', False):
-        if settings.USE_TZ:
-            dj_field_value = timezone.make_naive(dj_field_value, timezone=timezone.utc)
-        getattr(pb_obj, pb_field.name).FromDatetime(dj_field_value)
-
-
-def _datetimefield_from_pb(instance, dj_field_name, pb_field, pb_value):
-    """handling datetime field (Timestamp) object to dj field
-
-    :param dj_field_name: Currently target django field's name
-    :param pb_value: Currently processing protobuf message value
-    :returns: None
-    """
-    dt = pb_value.ToDatetime()
-    if settings.USE_TZ:
-        dt = timezone.localtime(timezone.make_aware(dt, timezone.utc))
-    # FIXME: not datetime field
-    setattr(instance, dj_field_name, dt)
-
-
-def _uuid_to_pb(pb_obj, pb_field, dj_field_value):
-    """handling Django UUIDField field
-
-    :param pb_obj: protobuf message obj which is return value of to_pb()
-    :param pb_field: protobuf message field which is current processing field
-    :param dj_field_value: Currently proecessing django field value
-    :returns: None
-    """
-    setattr(pb_obj, pb_field.name, str(dj_field_value))
-
-
-def _uuid_from_pb(instance, dj_field_name, pb_field, pb_value):
-    """handling string object to dj UUIDField
-
-    :param dj_field_name: Currently target django field's name
-    :param pb_value: Currently processing protobuf message value
-    :returns: None
-    """
-    setattr(instance, dj_field_name, uuid.UUID(pb_value))
-
-
 class DjangoPBModelError(Exception):
     pass
 

--- a/pb_model/tests/models.proto
+++ b/pb_model/tests/models.proto
@@ -34,3 +34,51 @@ message Main {
     bool bool_field=8;
     google.protobuf.Timestamp datetime_field = 9;
 }
+
+
+enum Enum {
+  Enum_NOTSET                                       = 0;
+  Enum_ONE                                          = 1;
+  Enum_TWO                                          = 2;
+}
+
+
+message Root {
+  uint32 uint32_field                               = 1;
+  int32 int32_field                                 = 2;
+  uint64 uint64_field                               = 3;
+  int64 int64_field                                 = 4;
+  float float_field                                 = 5;
+  double double_field                               = 6;
+  string string_field                               = 7;
+  bytes bytes_field                                 = 8;
+  bool bool_field                                   = 9;
+
+  Enum enum_field                                   = 10;
+  google.protobuf.Timestamp timestamp_field         = 11;
+  string uuid_field                                 = 12;
+
+  repeated uint32 repeated_uint32_field             = 13;
+  repeated string repeated_string_field             = 14;
+  repeated double repeated_double_field             = 15;
+  map<string, string> map_string_to_string_field    = 16;
+
+  Embedded message_field                            = 17;
+  repeated Embedded repeated_message_field          = 18;
+  map<string, Embedded> map_string_to_message_field = 19;
+
+  oneof options {
+    ListWrapper list_field_option                   = 20;
+    MapWrapper map_field_option                     = 21;
+  }
+
+  message Embedded {
+    int32 data                                      = 1;
+  }
+  message ListWrapper {
+    repeated string data                            = 1;
+  }
+  message MapWrapper {
+    map<string, string> data                        = 1;
+  }
+}

--- a/pb_model/tests/models.py
+++ b/pb_model/tests/models.py
@@ -41,3 +41,26 @@ class Main(ProtoBufMixin, models.Model):
 
     fk_field = models.ForeignKey(Relation, on_delete=models.DO_NOTHING)
     m2m_field = models.ManyToManyField(M2MRelation)
+
+
+class Embedded(ProtoBufMixin, models.Model):
+    pb_model = models_pb2.Root.Embedded
+    pb_2_dj_fields = '__all__'
+
+
+class ListWrapper(ProtoBufMixin, models.Model):
+    pb_model = models_pb2.Root.ListWrapper
+    pb_2_dj_fields = '__all__'
+
+
+class MapWrapper(ProtoBufMixin, models.Model):
+    pb_model = models_pb2.Root.MapWrapper
+    pb_2_dj_fields = '__all__'
+
+
+class Root(ProtoBufMixin, models.Model):
+    pb_model = models_pb2.Root
+    pb_2_dj_fields = '__all__'
+    pb_2_dj_field_map = {'uint32_field': 'uint32_field_renamed'}
+
+    uuid_field = models.UUIDField(null=True)

--- a/pb_model/tests/models_pb2.py
+++ b/pb_model/tests/models_pb2.py
@@ -3,11 +3,11 @@
 
 import sys
 _b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
+from google.protobuf.internal import enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -20,10 +20,41 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='models.proto',
   package='models',
   syntax='proto3',
-  serialized_pb=_b('\n\x0cmodels.proto\x12\x06models\x1a\x1fgoogle/protobuf/timestamp.proto\"#\n\x08Relation\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0b\n\x03num\x18\x02 \x01(\x05\"&\n\x0bM2MRelation\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0b\n\x03num\x18\x02 \x01(\x05\"\xc8\x02\n\x04Main\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x14\n\x0cstring_field\x18\x02 \x01(\t\x12\x15\n\rinteger_field\x18\x03 \x01(\x05\x12\x13\n\x0b\x66loat_field\x18\x04 \x01(\x02\x12+\n\rchoices_field\x18\x05 \x01(\x0e\x32\x14.models.Main.Options\x12\"\n\x08\x66k_field\x18\x06 \x01(\x0b\x32\x10.models.Relation\x12&\n\tm2m_field\x18\x07 \x03(\x0b\x32\x13.models.M2MRelation\x12\x12\n\nbool_field\x18\x08 \x01(\x08\x12\x32\n\x0e\x64\x61tetime_field\x18\t \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"1\n\x07Options\x12\x08\n\x04OPT0\x10\x00\x12\x08\n\x04OPT1\x10\x01\x12\x08\n\x04OPT2\x10\x02\x12\x08\n\x04OPT3\x10\x03\x62\x06proto3')
+  serialized_options=None,
+  serialized_pb=_b('\n\x0cmodels.proto\x12\x06models\x1a\x1fgoogle/protobuf/timestamp.proto\"#\n\x08Relation\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0b\n\x03num\x18\x02 \x01(\x05\"&\n\x0bM2MRelation\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0b\n\x03num\x18\x02 \x01(\x05\"\xc8\x02\n\x04Main\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x14\n\x0cstring_field\x18\x02 \x01(\t\x12\x15\n\rinteger_field\x18\x03 \x01(\x05\x12\x13\n\x0b\x66loat_field\x18\x04 \x01(\x02\x12+\n\rchoices_field\x18\x05 \x01(\x0e\x32\x14.models.Main.Options\x12\"\n\x08\x66k_field\x18\x06 \x01(\x0b\x32\x10.models.Relation\x12&\n\tm2m_field\x18\x07 \x03(\x0b\x32\x13.models.M2MRelation\x12\x12\n\nbool_field\x18\x08 \x01(\x08\x12\x32\n\x0e\x64\x61tetime_field\x18\t \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"1\n\x07Options\x12\x08\n\x04OPT0\x10\x00\x12\x08\n\x04OPT1\x10\x01\x12\x08\n\x04OPT2\x10\x02\x12\x08\n\x04OPT3\x10\x03\"\xc1\x08\n\x04Root\x12\x14\n\x0cuint32_field\x18\x01 \x01(\r\x12\x13\n\x0bint32_field\x18\x02 \x01(\x05\x12\x14\n\x0cuint64_field\x18\x03 \x01(\x04\x12\x13\n\x0bint64_field\x18\x04 \x01(\x03\x12\x13\n\x0b\x66loat_field\x18\x05 \x01(\x02\x12\x14\n\x0c\x64ouble_field\x18\x06 \x01(\x01\x12\x14\n\x0cstring_field\x18\x07 \x01(\t\x12\x13\n\x0b\x62ytes_field\x18\x08 \x01(\x0c\x12\x12\n\nbool_field\x18\t \x01(\x08\x12 \n\nenum_field\x18\n \x01(\x0e\x32\x0c.models.Enum\x12\x33\n\x0ftimestamp_field\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\nuuid_field\x18\x0c \x01(\t\x12\x1d\n\x15repeated_uint32_field\x18\r \x03(\r\x12\x1d\n\x15repeated_string_field\x18\x0e \x03(\t\x12\x1d\n\x15repeated_double_field\x18\x0f \x03(\x01\x12L\n\x1amap_string_to_string_field\x18\x10 \x03(\x0b\x32(.models.Root.MapStringToStringFieldEntry\x12,\n\rmessage_field\x18\x11 \x01(\x0b\x32\x15.models.Root.Embedded\x12\x35\n\x16repeated_message_field\x18\x12 \x03(\x0b\x32\x15.models.Root.Embedded\x12N\n\x1bmap_string_to_message_field\x18\x13 \x03(\x0b\x32).models.Root.MapStringToMessageFieldEntry\x12\x35\n\x11list_field_option\x18\x14 \x01(\x0b\x32\x18.models.Root.ListWrapperH\x00\x12\x33\n\x10map_field_option\x18\x15 \x01(\x0b\x32\x17.models.Root.MapWrapperH\x00\x1a=\n\x1bMapStringToStringFieldEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1aU\n\x1cMapStringToMessageFieldEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.models.Root.Embedded:\x02\x38\x01\x1a\x18\n\x08\x45mbedded\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x05\x1a\x1b\n\x0bListWrapper\x12\x0c\n\x04\x64\x61ta\x18\x01 \x03(\t\x1aj\n\nMapWrapper\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.models.Root.MapWrapper.DataEntry\x1a+\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\t\n\x07options*3\n\x04\x45num\x12\x0f\n\x0b\x45num_NOTSET\x10\x00\x12\x0c\n\x08\x45num_ONE\x10\x01\x12\x0c\n\x08\x45num_TWO\x10\x02\x62\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 
+_ENUM = _descriptor.EnumDescriptor(
+  name='Enum',
+  full_name='models.Enum',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Enum_NOTSET', index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Enum_ONE', index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='Enum_TWO', index=2, number=2,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=1557,
+  serialized_end=1608,
+)
+_sym_db.RegisterEnumDescriptor(_ENUM)
+
+Enum = enum_type_wrapper.EnumTypeWrapper(_ENUM)
+Enum_NOTSET = 0
+Enum_ONE = 1
+Enum_TWO = 2
 
 
 _MAIN_OPTIONS = _descriptor.EnumDescriptor(
@@ -34,23 +65,23 @@ _MAIN_OPTIONS = _descriptor.EnumDescriptor(
   values=[
     _descriptor.EnumValueDescriptor(
       name='OPT0', index=0, number=0,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='OPT1', index=1, number=1,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='OPT2', index=2, number=2,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='OPT3', index=3, number=3,
-      options=None,
+      serialized_options=None,
       type=None),
   ],
   containing_type=None,
-  options=None,
+  serialized_options=None,
   serialized_start=414,
   serialized_end=463,
 )
@@ -70,21 +101,21 @@ _RELATION = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='num', full_name='models.Relation.num', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -108,21 +139,21 @@ _M2MRELATION = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='num', full_name='models.M2MRelation.num', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -146,63 +177,63 @@ _MAIN = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='string_field', full_name='models.Main.string_field', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='integer_field', full_name='models.Main.integer_field', index=2,
       number=3, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='float_field', full_name='models.Main.float_field', index=3,
       number=4, type=2, cpp_type=6, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='choices_field', full_name='models.Main.choices_field', index=4,
       number=5, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='fk_field', full_name='models.Main.fk_field', index=5,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='m2m_field', full_name='models.Main.m2m_field', index=6,
       number=7, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='bool_field', full_name='models.Main.bool_field', index=7,
       number=8, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='datetime_field', full_name='models.Main.datetime_field', index=8,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -210,7 +241,7 @@ _MAIN = _descriptor.Descriptor(
   enum_types=[
     _MAIN_OPTIONS,
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -220,14 +251,413 @@ _MAIN = _descriptor.Descriptor(
   serialized_end=463,
 )
 
+
+_ROOT_MAPSTRINGTOSTRINGFIELDENTRY = _descriptor.Descriptor(
+  name='MapStringToStringFieldEntry',
+  full_name='models.Root.MapStringToStringFieldEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='models.Root.MapStringToStringFieldEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='models.Root.MapStringToStringFieldEntry.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=_b('8\001'),
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1233,
+  serialized_end=1294,
+)
+
+_ROOT_MAPSTRINGTOMESSAGEFIELDENTRY = _descriptor.Descriptor(
+  name='MapStringToMessageFieldEntry',
+  full_name='models.Root.MapStringToMessageFieldEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='models.Root.MapStringToMessageFieldEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='models.Root.MapStringToMessageFieldEntry.value', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=_b('8\001'),
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1296,
+  serialized_end=1381,
+)
+
+_ROOT_EMBEDDED = _descriptor.Descriptor(
+  name='Embedded',
+  full_name='models.Root.Embedded',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='data', full_name='models.Root.Embedded.data', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1383,
+  serialized_end=1407,
+)
+
+_ROOT_LISTWRAPPER = _descriptor.Descriptor(
+  name='ListWrapper',
+  full_name='models.Root.ListWrapper',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='data', full_name='models.Root.ListWrapper.data', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1409,
+  serialized_end=1436,
+)
+
+_ROOT_MAPWRAPPER_DATAENTRY = _descriptor.Descriptor(
+  name='DataEntry',
+  full_name='models.Root.MapWrapper.DataEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='models.Root.MapWrapper.DataEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='models.Root.MapWrapper.DataEntry.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=_b('8\001'),
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1501,
+  serialized_end=1544,
+)
+
+_ROOT_MAPWRAPPER = _descriptor.Descriptor(
+  name='MapWrapper',
+  full_name='models.Root.MapWrapper',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='data', full_name='models.Root.MapWrapper.data', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_ROOT_MAPWRAPPER_DATAENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1438,
+  serialized_end=1544,
+)
+
+_ROOT = _descriptor.Descriptor(
+  name='Root',
+  full_name='models.Root',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='uint32_field', full_name='models.Root.uint32_field', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='int32_field', full_name='models.Root.int32_field', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='uint64_field', full_name='models.Root.uint64_field', index=2,
+      number=3, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='int64_field', full_name='models.Root.int64_field', index=3,
+      number=4, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='float_field', full_name='models.Root.float_field', index=4,
+      number=5, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='double_field', full_name='models.Root.double_field', index=5,
+      number=6, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='string_field', full_name='models.Root.string_field', index=6,
+      number=7, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='bytes_field', full_name='models.Root.bytes_field', index=7,
+      number=8, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='bool_field', full_name='models.Root.bool_field', index=8,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='enum_field', full_name='models.Root.enum_field', index=9,
+      number=10, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='timestamp_field', full_name='models.Root.timestamp_field', index=10,
+      number=11, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='uuid_field', full_name='models.Root.uuid_field', index=11,
+      number=12, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='repeated_uint32_field', full_name='models.Root.repeated_uint32_field', index=12,
+      number=13, type=13, cpp_type=3, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='repeated_string_field', full_name='models.Root.repeated_string_field', index=13,
+      number=14, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='repeated_double_field', full_name='models.Root.repeated_double_field', index=14,
+      number=15, type=1, cpp_type=5, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='map_string_to_string_field', full_name='models.Root.map_string_to_string_field', index=15,
+      number=16, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='message_field', full_name='models.Root.message_field', index=16,
+      number=17, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='repeated_message_field', full_name='models.Root.repeated_message_field', index=17,
+      number=18, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='map_string_to_message_field', full_name='models.Root.map_string_to_message_field', index=18,
+      number=19, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='list_field_option', full_name='models.Root.list_field_option', index=19,
+      number=20, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='map_field_option', full_name='models.Root.map_field_option', index=20,
+      number=21, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_ROOT_MAPSTRINGTOSTRINGFIELDENTRY, _ROOT_MAPSTRINGTOMESSAGEFIELDENTRY, _ROOT_EMBEDDED, _ROOT_LISTWRAPPER, _ROOT_MAPWRAPPER, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='options', full_name='models.Root.options',
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=466,
+  serialized_end=1555,
+)
+
 _MAIN.fields_by_name['choices_field'].enum_type = _MAIN_OPTIONS
 _MAIN.fields_by_name['fk_field'].message_type = _RELATION
 _MAIN.fields_by_name['m2m_field'].message_type = _M2MRELATION
 _MAIN.fields_by_name['datetime_field'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _MAIN_OPTIONS.containing_type = _MAIN
+_ROOT_MAPSTRINGTOSTRINGFIELDENTRY.containing_type = _ROOT
+_ROOT_MAPSTRINGTOMESSAGEFIELDENTRY.fields_by_name['value'].message_type = _ROOT_EMBEDDED
+_ROOT_MAPSTRINGTOMESSAGEFIELDENTRY.containing_type = _ROOT
+_ROOT_EMBEDDED.containing_type = _ROOT
+_ROOT_LISTWRAPPER.containing_type = _ROOT
+_ROOT_MAPWRAPPER_DATAENTRY.containing_type = _ROOT_MAPWRAPPER
+_ROOT_MAPWRAPPER.fields_by_name['data'].message_type = _ROOT_MAPWRAPPER_DATAENTRY
+_ROOT_MAPWRAPPER.containing_type = _ROOT
+_ROOT.fields_by_name['enum_field'].enum_type = _ENUM
+_ROOT.fields_by_name['timestamp_field'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_ROOT.fields_by_name['map_string_to_string_field'].message_type = _ROOT_MAPSTRINGTOSTRINGFIELDENTRY
+_ROOT.fields_by_name['message_field'].message_type = _ROOT_EMBEDDED
+_ROOT.fields_by_name['repeated_message_field'].message_type = _ROOT_EMBEDDED
+_ROOT.fields_by_name['map_string_to_message_field'].message_type = _ROOT_MAPSTRINGTOMESSAGEFIELDENTRY
+_ROOT.fields_by_name['list_field_option'].message_type = _ROOT_LISTWRAPPER
+_ROOT.fields_by_name['map_field_option'].message_type = _ROOT_MAPWRAPPER
+_ROOT.oneofs_by_name['options'].fields.append(
+  _ROOT.fields_by_name['list_field_option'])
+_ROOT.fields_by_name['list_field_option'].containing_oneof = _ROOT.oneofs_by_name['options']
+_ROOT.oneofs_by_name['options'].fields.append(
+  _ROOT.fields_by_name['map_field_option'])
+_ROOT.fields_by_name['map_field_option'].containing_oneof = _ROOT.oneofs_by_name['options']
 DESCRIPTOR.message_types_by_name['Relation'] = _RELATION
 DESCRIPTOR.message_types_by_name['M2MRelation'] = _M2MRELATION
 DESCRIPTOR.message_types_by_name['Main'] = _MAIN
+DESCRIPTOR.message_types_by_name['Root'] = _ROOT
+DESCRIPTOR.enum_types_by_name['Enum'] = _ENUM
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Relation = _reflection.GeneratedProtocolMessageType('Relation', (_message.Message,), dict(
@@ -251,5 +681,63 @@ Main = _reflection.GeneratedProtocolMessageType('Main', (_message.Message,), dic
   ))
 _sym_db.RegisterMessage(Main)
 
+Root = _reflection.GeneratedProtocolMessageType('Root', (_message.Message,), dict(
 
+  MapStringToStringFieldEntry = _reflection.GeneratedProtocolMessageType('MapStringToStringFieldEntry', (_message.Message,), dict(
+    DESCRIPTOR = _ROOT_MAPSTRINGTOSTRINGFIELDENTRY,
+    __module__ = 'models_pb2'
+    # @@protoc_insertion_point(class_scope:models.Root.MapStringToStringFieldEntry)
+    ))
+  ,
+
+  MapStringToMessageFieldEntry = _reflection.GeneratedProtocolMessageType('MapStringToMessageFieldEntry', (_message.Message,), dict(
+    DESCRIPTOR = _ROOT_MAPSTRINGTOMESSAGEFIELDENTRY,
+    __module__ = 'models_pb2'
+    # @@protoc_insertion_point(class_scope:models.Root.MapStringToMessageFieldEntry)
+    ))
+  ,
+
+  Embedded = _reflection.GeneratedProtocolMessageType('Embedded', (_message.Message,), dict(
+    DESCRIPTOR = _ROOT_EMBEDDED,
+    __module__ = 'models_pb2'
+    # @@protoc_insertion_point(class_scope:models.Root.Embedded)
+    ))
+  ,
+
+  ListWrapper = _reflection.GeneratedProtocolMessageType('ListWrapper', (_message.Message,), dict(
+    DESCRIPTOR = _ROOT_LISTWRAPPER,
+    __module__ = 'models_pb2'
+    # @@protoc_insertion_point(class_scope:models.Root.ListWrapper)
+    ))
+  ,
+
+  MapWrapper = _reflection.GeneratedProtocolMessageType('MapWrapper', (_message.Message,), dict(
+
+    DataEntry = _reflection.GeneratedProtocolMessageType('DataEntry', (_message.Message,), dict(
+      DESCRIPTOR = _ROOT_MAPWRAPPER_DATAENTRY,
+      __module__ = 'models_pb2'
+      # @@protoc_insertion_point(class_scope:models.Root.MapWrapper.DataEntry)
+      ))
+    ,
+    DESCRIPTOR = _ROOT_MAPWRAPPER,
+    __module__ = 'models_pb2'
+    # @@protoc_insertion_point(class_scope:models.Root.MapWrapper)
+    ))
+  ,
+  DESCRIPTOR = _ROOT,
+  __module__ = 'models_pb2'
+  # @@protoc_insertion_point(class_scope:models.Root)
+  ))
+_sym_db.RegisterMessage(Root)
+_sym_db.RegisterMessage(Root.MapStringToStringFieldEntry)
+_sym_db.RegisterMessage(Root.MapStringToMessageFieldEntry)
+_sym_db.RegisterMessage(Root.Embedded)
+_sym_db.RegisterMessage(Root.ListWrapper)
+_sym_db.RegisterMessage(Root.MapWrapper)
+_sym_db.RegisterMessage(Root.MapWrapper.DataEntry)
+
+
+_ROOT_MAPSTRINGTOSTRINGFIELDENTRY._options = None
+_ROOT_MAPSTRINGTOMESSAGEFIELDENTRY._options = None
+_ROOT_MAPWRAPPER_DATAENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/pb_model/tests/tests.py
+++ b/pb_model/tests/tests.py
@@ -97,8 +97,8 @@ class ProtoBufConvertingTest(TestCase):
                 FieldDescriptor.TYPE_UINT64: dj_models.IntegerField
             }
 
-        assert ProtoBufMixin._pb_auto_field_type_mapping[FieldDescriptor.TYPE_UINT32] is dj_models.PositiveIntegerField
-        assert Parent._pb_auto_field_type_mapping[FieldDescriptor.TYPE_UINT32] is dj_models.IntegerField
+        assert ProtoBufMixin.pb_auto_field_type_mapping[FieldDescriptor.TYPE_UINT32] is dj_models.PositiveIntegerField
+        assert Parent.pb_auto_field_type_mapping[FieldDescriptor.TYPE_UINT32] is dj_models.IntegerField
 
         assert {f.name for f in Parent._meta.get_fields()} == {'child', 'id', 'uint32_field_renamed'}
         assert type(Parent._meta.get_field('uint32_field_renamed')) is dj_models.IntegerField

--- a/pb_model/tests/tests.py
+++ b/pb_model/tests/tests.py
@@ -1,8 +1,16 @@
+import datetime
+import uuid
+
 from django.test import TestCase
+from django.db import models as dj_models
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.protobuf.descriptor import FieldDescriptor
 
 # Create your tests here.
 
-from . import models
+from pb_model.models import ProtoBufMixin
+from . import models, models_pb2
 
 
 class ProtoBufConvertingTest(TestCase):
@@ -66,3 +74,80 @@ class ProtoBufConvertingTest(TestCase):
                 main_item.m2m_field.order_by('id').values_list('id', flat=True),
                 main_item2.m2m_field.order_by('id').values_list('id', flat=True))
         )
+    
+        main_item2.save()
+        main_item2 = models.Main.objects.get()
+        assert main_item.to_pb() == main_item2.to_pb()
+
+    def test_inheritance(self):
+        class Parent(ProtoBufMixin, dj_models.Model):
+            pb_model = models_pb2.Root
+            pb_2_dj_fields = ['uint32_field']
+            pb_2_dj_field_map = {'uint32_field': 'uint32_field_renamed'}
+            pb_auto_field_type_mapping = {
+                FieldDescriptor.TYPE_UINT32: dj_models.IntegerField
+            }
+
+        class Child(Parent):
+            pb_model = models_pb2.Root
+            pb_2_dj_fields = ['uint64_field']
+            pb_2_dj_field_map = {'uint64_field': 'uint64_field_renamed'}
+            pb_auto_field_type_mapping = {
+                FieldDescriptor.TYPE_UINT32: dj_models.FloatField,
+                FieldDescriptor.TYPE_UINT64: dj_models.IntegerField
+            }
+
+        assert ProtoBufMixin._pb_auto_field_type_mapping[FieldDescriptor.TYPE_UINT32] is dj_models.PositiveIntegerField
+        assert Parent._pb_auto_field_type_mapping[FieldDescriptor.TYPE_UINT32] is dj_models.IntegerField
+
+        assert {f.name for f in Parent._meta.get_fields()} == {'child', 'id', 'uint32_field_renamed'}
+        assert type(Parent._meta.get_field('uint32_field_renamed')) is dj_models.IntegerField
+
+        assert {f.name for f in Child._meta.get_fields()} == {'parent_ptr', 'id', 'uint32_field_renamed', 'uint64_field_renamed'}
+        assert type(Child._meta.get_field('uint32_field_renamed')) is dj_models.IntegerField
+        assert type(Child._meta.get_field('uint64_field_renamed')) is dj_models.IntegerField
+
+    def test_auto_fields(self):
+        timestamp = Timestamp()
+        timestamp.FromDatetime(datetime.datetime.now())
+        pb_object = models_pb2.Root(
+            uint32_field=1234,
+            uint64_field=123,
+            int64_field=123,
+            float_field=12.3,
+            double_field=12.3,
+            string_field='123',
+            bytes_field=b'123',
+            bool_field=True,
+            uuid_field=str(uuid.uuid4()),
+
+            enum_field=1,
+            timestamp_field=timestamp,
+            repeated_uint32_field=[1, 2, 3],
+            map_string_to_string_field={'qwe': 'asd'},
+
+            message_field=models_pb2.Root.Embedded(data=123),
+            repeated_message_field=[models_pb2.Root.Embedded(data=123), models_pb2.Root.Embedded(data=456), models_pb2.Root.Embedded(data=789)],
+            map_string_to_message_field={'qwe': models_pb2.Root.Embedded(data=123), 'asd': models_pb2.Root.Embedded(data=456)},
+
+            list_field_option=models_pb2.Root.ListWrapper(data=['qwe', 'asd', 'zxc'])
+        )
+
+        dj_object = models.Root()
+        dj_object.from_pb(pb_object)
+        dj_object.message_field.save()
+        dj_object.message_field = dj_object.message_field
+        for m in dj_object.repeated_message_field:
+            m.save()
+        for m in dj_object.map_string_to_message_field.values():
+            m.save()
+        dj_object.list_field_option.save()
+        dj_object.list_field_option = dj_object.list_field_option
+        dj_object.save()
+
+        dj_object_from_db = models.Root.objects.get()
+        assert [o.data for o in dj_object_from_db.repeated_message_field] == [123, 456, 789]
+        assert {k: o.data for k, o in dj_object_from_db.map_string_to_message_field.items()} == {'qwe': 123, 'asd': 456}
+        assert dj_object_from_db.uint32_field_renamed == pb_object.uint32_field
+        result = dj_object_from_db.to_pb()
+        assert pb_object == result


### PR DESCRIPTION
Enable automatic django model field generation based on protobuf message definition.
Custom fields implemented to support mapping to protobuf repeated and map fields, as well as more complex repeated and map many-to-many relations.
Had to drop django 1.8 support.

Let me know what you think.