### PR TITLE
Make ProtoBufMixin a proper subclass of Model

### DIFF
--- a/pb_model/models.py
+++ b/pb_model/models.py
@@ -147,7 +147,7 @@ class Meta(type(models.Model)):
         return field_type(to=related_type, related_name='%s_%s' % (own_type, field_name))
 
 
-class ProtoBufMixin(six.with_metaclass(Meta, object)):
+class ProtoBufMixin(six.with_metaclass(Meta, models.Model)):
     """This is mixin for model.Model.
     By setting attribute ``pb_model``, you can specify target ProtoBuf Message
     to handle django model.
@@ -155,6 +155,8 @@ class ProtoBufMixin(six.with_metaclass(Meta, object)):
     By settings attribute ``pb_2_dj_field_map``, you can mapping field from
     ProtoBuf to Django to handle schema migrations and message field chnages
     """
+    class Meta:
+        abstract = True
 
     pb_model = None
     pb_2_dj_fields = []  # list of pb field names that are mapped, special case pb_2_dj_fields = '__all__'


### PR DESCRIPTION
Django 2.2 detects classes in the app_installed.models module.

It seems that now they are detecting classes based on whether they are
inheriting django.db.base.ModelBase. Since ProtoBufMixin must be a
mixin with Model, its type needs to be a (subclass of) ModelBase,
which it is (since its metaclass is pb_model.Meta which is a subclass
of ModelBase).

Given that ProtoBufMixin must be now a valid Django module, we are
adding its class Meta with abstract=True, in order to cause minimum
hassle.

This entails that now subclasses of ProtoBufMixin are already Model,
and don't need to also include models.Model into the inheritance
chain. It also means that there is a spurious subclass in the middle
between Model and your model class, but that seems to be benign
enough, and Django should not break that if they aim not to break
compatibility with model inheritance in client apps.

Fix https://github.com/myyang/django-pb-model/issues/10