### PR TITLE
pb_model: fix autogen field of proxy model

### DIFF
--- a/pb_model/models.py
+++ b/pb_model/models.py
@@ -32,6 +32,11 @@ class Meta(type(models.Model)):
         self.pb_auto_field_type_mapping = self._pb_auto_field_type_mapping.copy()
         self.pb_auto_field_type_mapping.update(attrs.get('pb_auto_field_type_mapping', {}))
 
+        if self._meta.proxy:
+            # prevent duplicated field in proxy model
+            # ref: https://github.com/myyang/django-pb-model/issues/29
+            return
+
         if self.pb_model is not None:
             if self.pb_2_dj_fields == '__all__':
                 self.pb_2_dj_fields = self.pb_model.DESCRIPTOR.fields_by_name.keys()

--- a/pb_model/tests/models.py
+++ b/pb_model/tests/models.py
@@ -84,3 +84,8 @@ class Root(ProtoBufMixin, models.Model):
     uuid_field = models.UUIDField(null=True)
     inline_field = models.CharField(max_length=10, null=True)
     second_inline_field = models.CharField(max_length=10, null=True)
+
+
+class Proxy(Root):
+    class Meta:
+        proxy = True

--- a/pb_model/tests/tests.py
+++ b/pb_model/tests/tests.py
@@ -226,6 +226,15 @@ class ProtoBufConvertingTest(TestCase):
         result = dj_object_from_db.to_pb()
         assert pb_object == result
 
+        # test proxy model with auto field
+        proxy_object_from_db = models.Proxy.objects.get()
+        assert [o.data for o in proxy_object_from_db.repeated_message_field] == [123, 456, 789]
+        assert {k: o.data for k, o in proxy_object_from_db.map_string_to_message_field.items()} == {'qwe': 123, 'asd': 456}
+        assert proxy_object_from_db.uint32_field_renamed == pb_object.uint32_field
+        assert proxy_object_from_db.any_field == _any
+        result = proxy_object_from_db.to_pb()
+        assert pb_object == result
+
     def test_relation_depth_limit(self):
         deepter_relation_item = models.DeeperRelation.objects.create(num=2)
         relation_item = models.Relation.objects.create(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-pb-model',
-    version='0.3.1',
+    version='0.3.2',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
The Meta class automatically generates fields that lead to duplicated
fields of the original field and conflict occurs. This commit skips field
creation of the proxy model and adds related tests to secure this issue.

Fix #29