### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -384,7 +384,7 @@ And code:
     id: 1
     fk_field {
       id: 1,
-      deeper_ralation {
+      deeper_relation {
         id: 1
       }
     }

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Install
 
     python manage.py makemigrations
     python manage.py migrate
-    python manage.py collectstatic -l
+    python manage.py collectstatic --link
 
 4. Start hacking or using app.
 


### PR DESCRIPTION
- Use `--link` rather than `-l` 
  I think it's README so self-explanatory option is better than abbreviated one.
- Fix typo
  ralation -> relation