### PR TITLE
Feature adding all but these fields

### DIFF
--- a/pb_model/models.py
+++ b/pb_model/models.py
@@ -39,7 +39,8 @@ class Meta(type(models.Model)):
 
         if self.pb_model is not None:
             if self.pb_2_dj_fields == '__all__':
-                self.pb_2_dj_fields = self.pb_model.DESCRIPTOR.fields_by_name.keys()
+                all_fields = self.pb_model.DESCRIPTOR.fields_by_name.keys()
+                self.pb_2_dj_fields = [f for f in all_fields if f not in self.pb_2_dj_ignore_fields]
 
             for pb_field_name in self.pb_2_dj_fields:
                 pb_field_descriptor = self.pb_model.DESCRIPTOR.fields_by_name[pb_field_name]
@@ -177,6 +178,7 @@ class ProtoBufMixin(six.with_metaclass(Meta, models.Model)):
 
     pb_model = None
     pb_2_dj_fields = []  # list of pb field names that are mapped, special case pb_2_dj_fields = '__all__'
+    pb_2_dj_ignore_fields = []  # list to ignore fields if pb_2_dj_fields = '__all__'
     pb_2_dj_field_map = {}  # pb field in keys, dj field in value
 
     # defaults for models.DateTimeField and models.UUIDField

--- a/pb_model/tests/tests.py
+++ b/pb_model/tests/tests.py
@@ -343,3 +343,23 @@ class ProtoBufConvertingTest(TestCase):
             num=2, deeper_relation=deeper_relation_item)
 
         test_proto = deeper_relation_item.to_pb()
+
+    def test_ignore_fields(self):
+
+        fields_for_ignore = ['id', 'uint32_field']
+
+        class ParentAll(ProtoBufMixin, dj_models.Model):
+            pb_model = models_pb2.Root
+            pb_2_dj_fields = '__all__'
+
+        class ParentAllIgnore(ProtoBufMixin, dj_models.Model):
+            pb_model = models_pb2.Root
+            pb_2_dj_fields = '__all__'
+            pb_2_dj_ignore_fields = fields_for_ignore
+
+        parent_all_fields = [f.name for f in ParentAll._meta.get_fields()]
+        parent_ignore_fields = [f.name for f in ParentAllIgnore._meta.get_fields()]
+
+        assert len(parent_all_fields) > len(parent_ignore_fields)
+        assert set(fields_for_ignore).issubset(parent_all_fields)
+        assert not set(fields_for_ignore).issubset(parent_ignore_fields)


### PR DESCRIPTION
## Problem

I've been using ProtoBufMixin for some time but these days I came across a giant .proto and when applying ProtoBufMixin I felt the need to remove a single field, and the question came to me "why describe N fields in pb_2_dj_fields to not include just one if I could simply have a field in ProtoBufMixin that removes that single field"

## Description

just add a parameter [pb_2_dj_ ignore fields] that receives a list of fields that should not be used and I assume that pb_2_dj_fields is with __all__ and after getting all the fields from the proto I remove the ones I don't want